### PR TITLE
Create layout.conf

### DIFF
--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -1,0 +1,1 @@
+masters = gentoo


### PR DESCRIPTION
Address warning from portage:
!!! Repository 'overnight' is missing masters attribute in '/var/lib/layman/overnight/metadata/layout.conf'
!!! Set 'masters = gentoo' in this file for future compatibility
